### PR TITLE
Rename Object -> BaseObject for PHP 7.2 compatibility

### DIFF
--- a/src/Handler/BaseObject.php
+++ b/src/Handler/BaseObject.php
@@ -1,7 +1,7 @@
 <?php
 namespace Mock\Handler;
 
-class Object {
+class BaseObject {
     static public function handle($template, $count = null) {
         if ($count == null) {
             return self::_handle($template);

--- a/src/Handler/Basic.php
+++ b/src/Handler/Basic.php
@@ -4,7 +4,7 @@ namespace Mock\Handler;
 class Basic {
     static public function handle($template, $count = null) {
         if (is_array($template)) {
-            return Object::handle($template, $count); // 只有array支持count类型
+            return BaseObject::handle($template, $count); // 只有array支持count类型
         } else if (is_numeric($template)) {
             return Number::handle($template, $count);
         } else if (is_string($template)) {


### PR DESCRIPTION
Cannot use 'Object' as class name as it is reserved.
Rename Object -> BaseObject for PHP 7.2 compatibility